### PR TITLE
Add session storage and logging to auth service

### DIFF
--- a/src/lib/auth-service.ts
+++ b/src/lib/auth-service.ts
@@ -60,6 +60,8 @@ export const authenticateUser = async (
         });
 
         if (result.success && result.user) {
+          console.log("✅ API Login successful:", result.user);
+
           // Verificar estado de aprobación
           if (result.user.status === "pending") {
             return {
@@ -75,6 +77,19 @@ export const authenticateUser = async (
               error: "Tu cuenta está desactivada. Contacta al administrador.",
             };
           }
+
+          // Crear sesión local para mantener consistencia
+          const sessionData: SessionData = {
+            user: result.user,
+            loginTime: new Date(),
+            rememberMe,
+          };
+
+          // Guardar en localStorage
+          if (rememberMe) {
+            localStorage.setItem(REMEMBER_KEY, JSON.stringify(sessionData));
+          }
+          sessionStorage.setItem(SESSION_KEY, JSON.stringify(sessionData));
 
           return {
             success: true,

--- a/src/lib/auth-service.ts
+++ b/src/lib/auth-service.ts
@@ -97,6 +97,7 @@ export const authenticateUser = async (
           };
         }
 
+        console.log("❌ API Login failed:", result.error);
         return {
           success: false,
           error: result.error || "Credenciales incorrectas",


### PR DESCRIPTION
This change adds session management and logging to the authentication service:

- Add console logging for successful and failed API login attempts
- Create local session data with user info, login time, and remember preference
- Store session data in localStorage when "remember me" is enabled
- Store session data in sessionStorage for all login attempts
- Maintain session consistency across the application

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 35`

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f5a1ec85f1a54294b5c8ebe3a093f300</projectId>-->
<!--<branchName>echo-sanctuary</branchName>-->