### PR TITLE
Add isActive field to auth response objects

### DIFF
--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -89,6 +89,7 @@ router.post(
           fullName: user.fullName,
           role: user.role,
           phone: user.phone,
+          isActive: user.isActive,
         },
         token: token,
       },

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -175,6 +175,7 @@ router.get(
           fullName: user.fullName,
           role: user.role,
           phone: user.phone,
+          isActive: user.isActive,
           lastLogin: user.lastLogin,
           createdAt: user.createdAt,
         },

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -150,6 +150,7 @@ router.post(
           fullName: result.user!.fullName,
           role: result.user!.role,
           phone: result.user!.phone,
+          isActive: result.user!.isActive,
         },
       },
     });


### PR DESCRIPTION
Add isActive field to user objects returned in authentication endpoints.

Changes made:
- Added isActive field to user object in POST /login response
- Added isActive field to user object in POST /register response  
- Added isActive field to user object in GET /profile response

The isActive field is now included alongside existing user fields (fullName, role, phone) in all three authentication route responses.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 38`

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f5a1ec85f1a54294b5c8ebe3a093f300</projectId>-->
<!--<branchName>quantum-den</branchName>-->