### PR TITLE
Replace username with email in login flow

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -62,18 +62,18 @@ const Login = () => {
     }
   }, [navigate]);
 
-  // Handle registration success message and prefill username
+  // Handle registration success message and prefill email
   useEffect(() => {
     if (location.state?.message && location.state?.newUser) {
       setSuccessMessage(location.state.message);
       setFormData((prev) => ({
         ...prev,
-        username: location.state.newUser.username,
+        username: location.state.newUser.email,
       }));
 
       toast({
         title: "¡Bienvenido!",
-        description: `${location.state.newUser.fullName}, tu cuenta fue creada exitosamente. Inicia sesión con tu nuevo usuario: ${location.state.newUser.username}`,
+        description: `${location.state.newUser.fullName}, tu cuenta fue creada exitosamente. Inicia sesión con tu correo: ${location.state.newUser.email}`,
       });
 
       // Clear the state to prevent showing the message again
@@ -105,7 +105,7 @@ const Login = () => {
       if (result.success && result.user) {
         toast({
           title: "Bienvenido",
-          description: `Hola ${result.user.fullName}, has iniciado sesión exitosamente`,
+          description: `Hola ${result.user.fullName}, has iniciado sesi��n exitosamente`,
         });
 
         // Redirect based on user role

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -113,7 +113,7 @@ const Register = () => {
                 result.message ||
                 "Registro exitoso. Tu cuenta está pendiente de aprobación.",
               newUser: {
-                username: result.user.username,
+                email: result.user.email,
                 fullName: result.user.fullName,
               },
             },

--- a/src/pages/UserProfile.tsx
+++ b/src/pages/UserProfile.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -51,23 +51,47 @@ import {
   Plus,
 } from "lucide-react";
 import Navbar from "@/components/Navbar";
+import { getCurrentUser } from "@/lib/auth-service";
 
 const UserProfile = () => {
   const navigate = useNavigate();
   const [isEditing, setIsEditing] = useState(false);
   const [profileData, setProfileData] = useState({
-    firstName: "María",
-    lastName: "González",
-    email: "maria.gonzalez@email.com",
-    phone: "+503 7888-9999",
-    address: "San Salvador, El Salvador",
-    birthDate: "1992-03-15",
-    nationality: "Salvadoreña",
-    document: "12345678-9",
-    memberSince: "2023-01-15",
+    firstName: "",
+    lastName: "",
+    email: "",
+    phone: "",
+    address: "",
+    birthDate: "",
+    nationality: "",
+    document: "",
+    memberSince: "",
     preferredLanguage: "es",
     currency: "USD",
   });
+
+  // Load user data from session
+  useEffect(() => {
+    const currentUser = getCurrentUser();
+    if (currentUser) {
+      setProfileData({
+        firstName: currentUser.firstName || "",
+        lastName: currentUser.lastName || "",
+        email: currentUser.email || "",
+        phone: currentUser.phone || "",
+        address: currentUser.address || "San Salvador, El Salvador",
+        birthDate: currentUser.birthDate || "",
+        nationality: currentUser.nationality || "Salvadoreña",
+        document: currentUser.documentNumber || "",
+        memberSince: currentUser.createdAt || "2023-01-15",
+        preferredLanguage: currentUser.preferredLanguage || "es",
+        currency: "USD",
+      });
+    } else {
+      // Redirect to login if no user session
+      navigate("/login", { replace: true });
+    }
+  }, [navigate]);
 
   const [notifications, setNotifications] = useState({
     email: true,


### PR DESCRIPTION
Updates the login and registration flow to use email instead of username:

- Login.tsx: Changed prefill logic to use email from newUser object instead of username
- Login.tsx: Updated toast message to reference "correo" instead of "usuario"
- Register.tsx: Modified navigation state to pass email instead of username
- UserProfile.tsx: Added useEffect to load user data from session using getCurrentUser()
- UserProfile.tsx: Replaced hardcoded profile data with dynamic data from user session
- UserProfile.tsx: Added redirect to login if no user session exists

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 39`

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f5a1ec85f1a54294b5c8ebe3a093f300</projectId>-->
<!--<branchName>zen-verse</branchName>-->