### PR TITLE
Add optional fields to interfaces and fix data handling

### DIFF
--- a/src/lib/api-service.ts
+++ b/src/lib/api-service.ts
@@ -84,6 +84,11 @@ interface Accommodation {
   amenities: string[];
   images?: string[];
   description?: string;
+  pricing?: {
+    weekday: number;
+    weekend: number;
+    holiday: number;
+  };
 }
 
 interface Reservation {

--- a/src/lib/registration-service.ts
+++ b/src/lib/registration-service.ts
@@ -25,6 +25,7 @@ export interface RegistrationResult {
   success: boolean;
   user?: any;
   error?: string;
+  message?: string;
 }
 
 // Validaciones de campo

--- a/src/lib/user-database.ts
+++ b/src/lib/user-database.ts
@@ -21,6 +21,7 @@ export interface User {
   status?: "pending" | "approved" | "rejected";
   lastLogin?: Date;
   createdAt: Date;
+  profileImage?: string;
 }
 
 // Definir permisos por rol

--- a/src/pages/AdminCalendar.tsx
+++ b/src/pages/AdminCalendar.tsx
@@ -61,12 +61,19 @@ const AdminCalendar = () => {
   const [selectedAccommodation, setSelectedAccommodation] = useState("all");
   const [selectedDates, setSelectedDates] = useState<Date[]>([]);
   const [isBlockDialogOpen, setIsBlockDialogOpen] = useState(false);
-  const [blockForm, setBlockForm] = useState({
+  const [blockForm, setBlockForm] = useState<{
+    accommodationId: string;
+    startDate: string;
+    endDate: string;
+    reason: string;
+    type: "maintenance" | "personal" | "other";
+    notes: string;
+  }>({
     accommodationId: "",
     startDate: "",
     endDate: "",
     reason: "",
-    type: "maintenance" as const,
+    type: "maintenance",
     notes: "",
   });
   const [loading, setLoading] = useState(true);
@@ -79,7 +86,7 @@ const AdminCalendar = () => {
     try {
       setLoading(true);
       const accommodationsData = await apiGetAccommodations();
-      setAccommodations(accommodationsData.accommodations);
+      setAccommodations(accommodationsData);
 
       // Cargar fechas bloqueadas mock
       setBlockedDates(getMockBlockedDates());

--- a/src/pages/AdminReservations.tsx
+++ b/src/pages/AdminReservations.tsx
@@ -843,26 +843,25 @@ const AdminReservations = () => {
                     <SelectValue placeholder="Seleccionar alojamiento" />
                   </SelectTrigger>
                   <SelectContent>
-                    {(Array.isArray(accommodations)
-                      ? accommodations
-                      : accommodations?.accommodations || []
-                    ).map((accommodation) => (
-                      <SelectItem
-                        key={accommodation.id}
-                        value={accommodation.id}
-                      >
-                        <div className="flex items-center space-x-2">
-                          <MapPin className="h-3 w-3 text-blue-600" />
-                          <span>
-                            {accommodation.name} -{" "}
-                            {accommodation.location === "el-sunzal"
-                              ? "El Sunzal"
-                              : "Corinto"}
-                            (Cap: {accommodation.capacity})
-                          </span>
-                        </div>
-                      </SelectItem>
-                    ))}
+                    {(Array.isArray(accommodations) ? accommodations : []).map(
+                      (accommodation) => (
+                        <SelectItem
+                          key={accommodation.id}
+                          value={accommodation.id}
+                        >
+                          <div className="flex items-center space-x-2">
+                            <MapPin className="h-3 w-3 text-blue-600" />
+                            <span>
+                              {accommodation.name} -{" "}
+                              {accommodation.location === "el-sunzal"
+                                ? "El Sunzal"
+                                : "Corinto"}
+                              (Cap: {accommodation.capacity})
+                            </span>
+                          </div>
+                        </SelectItem>
+                      ),
+                    )}
                   </SelectContent>
                 </Select>
               </div>


### PR DESCRIPTION
This pull request adds several optional fields to existing interfaces and fixes data handling inconsistencies:

**Interface Updates:**
- Add optional `pricing` field to `Accommodation` interface with weekday, weekend, and holiday rates
- Add optional `message` field to `RegistrationResult` interface  
- Add optional `profileImage` field to `User` interface

**Type Safety Improvements:**
- Add explicit type annotation to `blockForm` state in AdminCalendar component
- Change `type` field from const assertion to string literal type

**Data Handling Fixes:**
- Fix accommodations data access in AdminCalendar by removing `.accommodations` property access
- Simplify accommodations array handling in AdminReservations by removing conditional property access
- Ensure consistent array handling for accommodation mapping

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 48`

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>cbbef9f634334515bae23285d1b65072</projectId>-->
<!--<branchName>mystic-oasis</branchName>-->