### PR TITLE
Add price and status fields to accommodation objects

### DIFF
--- a/src/pages/AdminAccommodations.tsx
+++ b/src/pages/AdminAccommodations.tsx
@@ -112,6 +112,8 @@ const AdminAccommodations = () => {
       type: "apartamento",
       location: "el-sunzal",
       capacity: 2,
+      price: 230,
+      status: "available",
       description:
         "Cómodo apartamento con vista directa al mar, perfecto para parejas. Ubicado en el primer piso con fácil acceso y todas las comodidades necesarias.",
       amenities: ["Wi-Fi", "Aire acondicionado", "TV", "Kitchenette"],
@@ -129,6 +131,8 @@ const AdminAccommodations = () => {
       type: "apartamento",
       location: "el-sunzal",
       capacity: 2,
+      price: 210,
+      status: "available",
       description:
         "Apartamento acogedor con vista parcial al mar. Ideal para una estancia romántica con todas las comodidades modernas.",
       amenities: ["Wi-Fi", "Aire acondicionado", "TV", "Kitchenette"],
@@ -146,6 +150,8 @@ const AdminAccommodations = () => {
       type: "apartamento",
       location: "el-sunzal",
       capacity: 4,
+      price: 250,
+      status: "available",
       description:
         "Espacioso apartamento para familias con vista premium al mar. Segundo piso con balcón privado y cocina completa.",
       amenities: [
@@ -169,6 +175,8 @@ const AdminAccommodations = () => {
       type: "apartamento",
       location: "el-sunzal",
       capacity: 4,
+      price: 225,
+      status: "available",
       description:
         "Apartamento familiar con vista al jardín tropical. Perfecto para familias que buscan tranquilidad y confort.",
       amenities: ["Wi-Fi", "Aire acondicionado", "TV", "Cocina completa"],
@@ -186,6 +194,8 @@ const AdminAccommodations = () => {
       type: "apartamento",
       location: "el-sunzal",
       capacity: 6,
+      price: 350,
+      status: "available",
       description:
         "Penthouse de lujo con todas las comodidades para grupos grandes. Vista panorámica espectacular y terraza privada con jacuzzi.",
       amenities: [
@@ -210,6 +220,8 @@ const AdminAccommodations = () => {
       type: "apartamento",
       location: "el-sunzal",
       capacity: 6,
+      price: 320,
+      status: "available",
       description:
         "Amplio apartamento con vista lateral al mar. Excelente para grupos grandes con terraza amplia y múltiples comodidades.",
       amenities: [
@@ -235,6 +247,8 @@ const AdminAccommodations = () => {
       type: "casa",
       location: "el-sunzal",
       capacity: 6,
+      price: 450,
+      status: "available",
       description:
         "Casa diseñada especialmente para surfistas con acceso directo al break. Incluye almacenamiento para tablas y ducha exterior.",
       amenities: [
@@ -256,6 +270,8 @@ const AdminAccommodations = () => {
       type: "casa",
       location: "el-sunzal",
       capacity: 8,
+      price: 550,
+      status: "available",
       description:
         "Casa amplia y familiar con todas las comodidades para grupos grandes. Jardín privado, BBQ y sala de juegos incluidos.",
       amenities: [
@@ -277,6 +293,8 @@ const AdminAccommodations = () => {
       type: "casa",
       location: "el-sunzal",
       capacity: 6,
+      price: 500,
+      status: "available",
       description:
         "Casa elevada con vista panorámica espectacular del océano. Jacuzzi exterior, terraza multinivel y hamacas.",
       amenities: [
@@ -300,6 +318,8 @@ const AdminAccommodations = () => {
       type: "suite" as const,
       location: "el-sunzal" as const,
       capacity: 2 + Math.floor(i / 4),
+      price: 320 + i * 15,
+      status: "available" as const,
       description: `Suite de lujo número ${i + 1} con servicios premium incluidos. Diseño elegante con vista panorámica al océano Pacífico.`,
       amenities: [
         "Wi-Fi",
@@ -331,6 +351,8 @@ const AdminAccommodations = () => {
       type: "casa" as const,
       location: "corinto" as const,
       capacity: 4 + Math.floor(i / 2),
+      price: 280 + i * 25,
+      status: (i !== 3 ? "available" : "maintenance") as const,
       description: `Casa moderna ${i + 1} en Corinto con vista al lago. Ambiente tranquilo y relajante perfecto para desconectarse de la rutina.`,
       amenities: [
         "Wi-Fi",

--- a/src/pages/AdminAccommodationsUpdated.tsx
+++ b/src/pages/AdminAccommodationsUpdated.tsx
@@ -115,6 +115,8 @@ const AdminAccommodationsUpdated = () => {
       type: "apartamento",
       location: "el-sunzal",
       capacity: 2,
+      price: 230,
+      status: "available",
       description:
         "Cómodo apartamento con vista directa al mar, perfecto para parejas. Ubicado en el primer piso con fácil acceso y todas las comodidades necesarias.",
       amenities: ["Wi-Fi", "Aire acondicionado", "TV", "Kitchenette"],
@@ -132,6 +134,8 @@ const AdminAccommodationsUpdated = () => {
       type: "apartamento",
       location: "el-sunzal",
       capacity: 2,
+      price: 210,
+      status: "available",
       description:
         "Apartamento acogedor con vista parcial al mar. Ideal para una estancia romántica con todas las comodidades modernas.",
       amenities: ["Wi-Fi", "Aire acondicionado", "TV", "Kitchenette"],
@@ -149,6 +153,8 @@ const AdminAccommodationsUpdated = () => {
       type: "apartamento",
       location: "el-sunzal",
       capacity: 4,
+      price: 250,
+      status: "available",
       description:
         "Espacioso apartamento para familias con vista premium al mar. Segundo piso con balcón privado y cocina completa.",
       amenities: [
@@ -172,6 +178,8 @@ const AdminAccommodationsUpdated = () => {
       type: "apartamento",
       location: "el-sunzal",
       capacity: 4,
+      price: 225,
+      status: "available",
       description:
         "Apartamento familiar con vista al jardín tropical. Perfecto para familias que buscan tranquilidad y confort.",
       amenities: ["Wi-Fi", "Aire acondicionado", "TV", "Cocina completa"],
@@ -189,6 +197,8 @@ const AdminAccommodationsUpdated = () => {
       type: "apartamento",
       location: "el-sunzal",
       capacity: 6,
+      price: 350,
+      status: "available",
       description:
         "Penthouse de lujo con todas las comodidades para grupos grandes. Vista panorámica espectacular y terraza privada con jacuzzi.",
       amenities: [
@@ -213,6 +223,8 @@ const AdminAccommodationsUpdated = () => {
       type: "apartamento",
       location: "el-sunzal",
       capacity: 6,
+      price: 320,
+      status: "available",
       description:
         "Amplio apartamento con vista lateral al mar. Excelente para grupos grandes con terraza amplia y múltiples comodidades.",
       amenities: [
@@ -238,6 +250,8 @@ const AdminAccommodationsUpdated = () => {
       type: "casa",
       location: "el-sunzal",
       capacity: 6,
+      price: 450,
+      status: "available",
       description:
         "Casa diseñada especialmente para surfistas con acceso directo al break. Incluye almacenamiento para tablas y ducha exterior.",
       amenities: [
@@ -259,6 +273,8 @@ const AdminAccommodationsUpdated = () => {
       type: "casa",
       location: "el-sunzal",
       capacity: 8,
+      price: 550,
+      status: "available",
       description:
         "Casa amplia y familiar con todas las comodidades para grupos grandes. Jardín privado, BBQ y sala de juegos incluidos.",
       amenities: [
@@ -280,6 +296,8 @@ const AdminAccommodationsUpdated = () => {
       type: "casa",
       location: "el-sunzal",
       capacity: 6,
+      price: 500,
+      status: "available",
       description:
         "Casa elevada con vista panorámica espectacular del océano. Jacuzzi exterior, terraza multinivel y hamacas.",
       amenities: [
@@ -303,6 +321,8 @@ const AdminAccommodationsUpdated = () => {
       type: "suite" as const,
       location: "el-sunzal" as const,
       capacity: 2 + Math.floor(i / 4),
+      price: 320 + i * 15,
+      status: "available" as const,
       description: `Suite de lujo número ${i + 1} con servicios premium incluidos. Diseño elegante con vista panorámica al océano Pacífico.`,
       amenities: [
         "Wi-Fi",
@@ -334,6 +354,8 @@ const AdminAccommodationsUpdated = () => {
       type: "apartamento",
       location: "corinto",
       capacity: 2,
+      price: 180,
+      status: "available",
       description:
         "Apartamento con hermosa vista al lago. Ambiente tranquilo y relajante ideal para una escapada romántica.",
       amenities: ["Wi-Fi", "Aire acondicionado", "TV", "Kitchenette"],
@@ -351,6 +373,8 @@ const AdminAccommodationsUpdated = () => {
       type: "apartamento",
       location: "corinto",
       capacity: 2,
+      price: 170,
+      status: "available",
       description:
         "Acogedor apartamento en Corinto con vista parcial. Perfecto para una estancia tranquila en contacto con la naturaleza.",
       amenities: ["Wi-Fi", "Aire acondicionado", "TV", "Kitchenette"],
@@ -368,6 +392,8 @@ const AdminAccommodationsUpdated = () => {
       type: "apartamento",
       location: "corinto",
       capacity: 4,
+      price: 210,
+      status: "available",
       description:
         "Apartamento familiar con vista premium al lago. Balcón privado y cocina completa para una estancia cómoda.",
       amenities: [
@@ -391,6 +417,8 @@ const AdminAccommodationsUpdated = () => {
       type: "apartamento",
       location: "corinto",
       capacity: 4,
+      price: 200,
+      status: "available",
       description:
         "Apartamento con vista al jardín tropical. Espacioso y confortable, ideal para familias que buscan tranquilidad.",
       amenities: ["Wi-Fi", "Aire acondicionado", "TV", "Cocina completa"],
@@ -408,6 +436,8 @@ const AdminAccommodationsUpdated = () => {
       type: "apartamento",
       location: "corinto",
       capacity: 6,
+      price: 280,
+      status: "available",
       description:
         "Penthouse en Corinto con vista espectacular. Terraza amplia y cocina gourmet para grupos grandes.",
       amenities: [
@@ -431,6 +461,8 @@ const AdminAccommodationsUpdated = () => {
       type: "apartamento",
       location: "corinto",
       capacity: 6,
+      price: 270,
+      status: "available",
       description:
         "Apartamento espacioso con vista lateral al lago. Terraza privada y todas las comodidades para una estancia perfecta.",
       amenities: [
@@ -456,6 +488,8 @@ const AdminAccommodationsUpdated = () => {
       type: "casa" as const,
       location: "corinto" as const,
       capacity: 4 + Math.floor(i / 2),
+      price: 280 + i * 25,
+      status: (i !== 3 ? "available" : "maintenance") as const,
       description: `Casa moderna ${i + 1} en Corinto con vista al lago. Ambiente tranquilo y relajante perfecto para desconectarse de la rutina.`,
       amenities: [
         "Wi-Fi",


### PR DESCRIPTION
Add price and status properties to all accommodation objects in AdminAccommodations and AdminAccommodationsUpdated components.

Changes include:
- Added price field with specific values for each accommodation (ranging from $170-$550)
- Added status field with "available" for most accommodations and "maintenance" for one Corinto casa
- Applied changes to apartments, houses, and suites across el-sunzal and corinto locations
- Updated both static accommodation objects and dynamically generated ones

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 50`

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e5ebc810421a43ffb28a30abb83edbb9</projectId>-->
<!--<branchName>spark-zone</branchName>-->