### PR TITLE
Add null checks to proxy target and URL concatenation

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig(({ mode }) => ({
               req.method,
               req.url,
               "→",
-              options.target + req.url,
+              (options.target || "") + (req.url || ""),
             );
           });
           proxy.on("proxyRes", (proxyRes, req, res) => {


### PR DESCRIPTION
Add null/undefined checks when concatenating proxy target and request URL to prevent potential runtime errors.

Changes:
- Replace `options.target + req.url` with `(options.target || "") + (req.url || "")`
- Ensures safe string concatenation even if either value is null or undefined

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 55`

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e5ebc810421a43ffb28a30abb83edbb9</projectId>-->
<!--<branchName>pixel-lab</branchName>-->