### PR TITLE
Update auth redirects to use backoffice login paths

### DIFF
--- a/src/components/AdminProtectedRoute.tsx
+++ b/src/components/AdminProtectedRoute.tsx
@@ -21,7 +21,7 @@ const AdminProtectedRoute = ({
   useEffect(() => {
     // Verificar autenticación
     if (!requireAuth()) {
-      navigate("/login");
+      navigate("/backoffice/login");
       return;
     }
 
@@ -35,8 +35,24 @@ const AdminProtectedRoute = ({
         return;
       }
 
-      // Si no tiene permisos suficientes
-      navigate("/dashboard");
+      // Si no tiene permisos suficientes pero es staff, mantener en backoffice
+      if (
+        currentUser &&
+        [
+          "super_admin",
+          "atencion_miembro",
+          "anfitrion",
+          "monitor",
+          "mercadeo",
+          "recepcion",
+        ].includes(currentUser.role)
+      ) {
+        navigate("/admin/dashboard");
+        return;
+      }
+
+      // Si no es staff, redirigir al login del backoffice
+      navigate("/backoffice/login");
       return;
     }
   }, [navigate, requiredRole]);

--- a/src/components/RouteGuard.tsx
+++ b/src/components/RouteGuard.tsx
@@ -54,10 +54,16 @@ const RouteGuard = ({ children }: RouteGuardProps) => {
 
     // Si es ruta protegida, verificar autenticación
     if (!requireAuth()) {
+      // Detectar si estamos en contexto de backoffice
+      const isBackofficeContext =
+        currentPath.startsWith("/admin") ||
+        currentPath.startsWith("/backoffice");
+
+      const loginPath = isBackofficeContext ? "/backoffice/login" : "/login";
       console.log(
-        "RouteGuard: Protected route, auth failed, redirecting to login",
+        `RouteGuard: Protected route, auth failed, redirecting to ${loginPath} (context: ${isBackofficeContext ? "backoffice" : "main"})`,
       );
-      navigate("/login", { replace: true });
+      navigate(loginPath, { replace: true });
       return;
     }
 

--- a/src/components/RouteGuard.tsx
+++ b/src/components/RouteGuard.tsx
@@ -30,6 +30,7 @@ const RouteGuard = ({ children }: RouteGuardProps) => {
     "/corinto",
     "/el-sunzal",
     "/backoffice",
+    "/backoffice/login",
   ];
 
   // Función para verificar si es ruta pública

--- a/src/lib/auth-service.ts
+++ b/src/lib/auth-service.ts
@@ -276,7 +276,13 @@ export const logout = async (): Promise<void> => {
 
   // Limpiar historial para prevenir navegación hacia atrás
   if (window.history.replaceState) {
-    window.history.replaceState(null, "", "/login");
+    // Detectar si estamos en contexto de backoffice
+    const isBackofficeContext =
+      window.location.pathname.startsWith("/admin") ||
+      window.location.pathname.startsWith("/backoffice");
+
+    const loginPath = isBackofficeContext ? "/backoffice/login" : "/login";
+    window.history.replaceState(null, "", loginPath);
   }
 };
 

--- a/src/pages/AdminRegistrationRequests.tsx
+++ b/src/pages/AdminRegistrationRequests.tsx
@@ -89,9 +89,9 @@ const AdminRegistrationRequests = () => {
     // Verificar autenticación antes de cargar datos
     if (!requireAuth()) {
       console.log(
-        "AdminRegistrationRequests: Not authenticated, redirecting to login",
+        "AdminRegistrationRequests: Not authenticated, redirecting to backoffice login",
       );
-      navigate("/login");
+      navigate("/backoffice/login");
       return;
     }
     loadRequests();

--- a/src/pages/AdminUsers.tsx
+++ b/src/pages/AdminUsers.tsx
@@ -110,8 +110,10 @@ const AdminUsers = () => {
   useEffect(() => {
     // Verificar autenticación antes de cargar datos
     if (!requireAuth()) {
-      console.log("AdminUsers: Not authenticated, redirecting to login");
-      navigate("/login");
+      console.log(
+        "AdminUsers: Not authenticated, redirecting to backoffice login",
+      );
+      navigate("/backoffice/login");
       return;
     }
     loadUsers();


### PR DESCRIPTION
Updates authentication redirect logic to use context-aware login paths.

Changes made:
- Modified AdminProtectedRoute to redirect to `/backoffice/login` instead of `/login`
- Added role-based navigation logic for staff users without sufficient permissions
- Updated RouteGuard to detect backoffice context and redirect accordingly
- Modified auth-service logout function to use appropriate login path based on context
- Updated AdminRegistrationRequests and AdminUsers components to redirect to backoffice login
- Added `/backoffice/login` to public routes list in RouteGuard

The system now distinguishes between main application context and backoffice context when performing authentication redirects.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 59`

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>30e8a3bc1eb54e9ca548553a52f0937e</projectId>-->
<!--<branchName>curry-garden</branchName>-->