### PR TITLE
Update SelectItem value for no users available state

### DIFF
--- a/src/pages/AdminReservations.tsx
+++ b/src/pages/AdminReservations.tsx
@@ -911,7 +911,7 @@ const AdminReservations = () => {
                     </SelectTrigger>
                     <SelectContent>
                       {users.length === 0 ? (
-                        <SelectItem value="" disabled>
+                        <SelectItem value="no-users-available" disabled>
                           No hay usuarios disponibles
                         </SelectItem>
                       ) : (


### PR DESCRIPTION
Changes the value attribute of the disabled SelectItem from an empty string to "no-users-available" when no users are available in the AdminReservations component.

This provides a more descriptive value for the disabled state while maintaining the same user-facing text "No hay usuarios disponibles".

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 63`

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fe46c84feea442e6972aa584e1288366</projectId>-->
<!--<branchName>quantum-sanctuary</branchName>-->