### PR TITLE
Add Building2 icon import to AdminReservations

### DIFF
--- a/src/pages/AdminReservations.tsx
+++ b/src/pages/AdminReservations.tsx
@@ -63,6 +63,7 @@ import {
   AlertCircle,
   MapPin,
   Filter,
+  Building2,
 } from "lucide-react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import AdminLayout from "@/components/AdminLayout";


### PR DESCRIPTION
Adds Building2 icon to the lucide-react imports in AdminReservations.tsx.

The Building2 icon is imported alongside existing icons (AlertCircle, MapPin, Filter) from the lucide-react library.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 68`

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fe46c84feea442e6972aa584e1288366</projectId>-->
<!--<branchName>quantum-haven</branchName>-->