### PR TITLE
Add type assertions to reservation API responses

### DIFF
--- a/src/lib/api-service.ts
+++ b/src/lib/api-service.ts
@@ -452,16 +452,16 @@ export const apiGetReservations = async (
       // Handle different response formats
       if (isAdmin && result.data.reservations) {
         // Admin endpoint returns { data: { reservations: [...], pagination: {...} } }
-        return result.data.reservations;
+        return result.data.reservations as Reservation[];
       } else if (Array.isArray(result.data)) {
         // Regular endpoint returns array directly
-        return result.data;
+        return result.data as Reservation[];
       } else if (
         result.data.reservations &&
         Array.isArray(result.data.reservations)
       ) {
         // Fallback for wrapped array format
-        return result.data.reservations;
+        return result.data.reservations as Reservation[];
       }
     }
     throw new Error(result.error || "Failed to fetch reservations");


### PR DESCRIPTION
Add explicit type assertions to reservation data returned from API endpoints.

Changes made:
- Added `as Reservation[]` type assertion to admin endpoint response
- Added `as Reservation[]` type assertion to regular endpoint response  
- Added `as Reservation[]` type assertion to fallback wrapped array response

All three return paths in the apiGetReservations function now include explicit TypeScript type assertions to ensure proper typing of the returned reservation arrays.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 70`

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fe46c84feea442e6972aa584e1288366</projectId>-->
<!--<branchName>flare-realm</branchName>-->