### PR TITLE
Fix mock API condition to check email configuration

### DIFF
--- a/src/lib/mock-api.ts
+++ b/src/lib/mock-api.ts
@@ -96,9 +96,10 @@ export const mockSendResetSMS = async (
 
 // Utility to check if we should use mock APIs
 export const shouldUseMockAPI = (): boolean => {
-  // Use mock API in development when backend is not available
-  return true;
-  // return (
-  //   process.env.NODE_ENV === "development" || !process.env.REACT_APP_API_URL
-  // );
+  // Use mock API only when email is not properly configured
+  return (
+    !process.env.EMAIL_PASSWORD ||
+    process.env.EMAIL_PASSWORD === "REEMPLAZAR_CON_CONTRASEÑA_REAL" ||
+    process.env.EMAIL_PASSWORD === "development-password"
+  );
 };


### PR DESCRIPTION
## Purpose

The user was experiencing issues with email functionality during development. While the mock email system was working correctly (showing email content in console), the application was always using mock APIs regardless of actual email configuration. This change ensures that real email services are used when properly configured.

## Code changes

- Modified `shouldUseMockAPI()` function in `mock-api.ts` to check email configuration instead of always returning `true`
- Added conditional logic to use mock API only when:
  - `EMAIL_PASSWORD` environment variable is not set
  - `EMAIL_PASSWORD` contains placeholder values like "REEMPLAZAR_CON_CONTRASEÑA_REAL" 
  - `EMAIL_PASSWORD` is set to "development-password"
- Removed hardcoded `return true` that was forcing mock API usage in all scenarios

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7a9951cb2a8a483cbac9777f138a40a9</projectId>-->
<!--<branchName>aura-realm</branchName>-->